### PR TITLE
Expand documentation for Pure Data and OSC Messages

### DIFF
--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -23,14 +23,25 @@
     git clone https://github.com/sudar/Arduino-Makefile.git
 
 ## Program Synopsis
-- Teensy and E256 brekout communicate via SPI (Hardware).
+- Teensy and E256 breakout communicate via SPI (Hardware).
 - The Arduio sketch implemant rows and columns scaning algorithm with synchronous **dual ADC sampling**.
   - COLS = Two 8_Bits shift registers connected directly to the matrix columns.
   - ROWS = One 8_Bits shift register connected to two analog multiplexers that sens the matrix rows.
 - The 16x16 Analog sensors values are interpolated into 64x64 with a bilinear algorithm.
 - The blob tracking algorithm (connected component labeling) is applyed onto the interpolated matrix.
 - Each blob are tracked with persistent ID (this is done with linked list implementation).
-- The blobs coordinates, size and presure are transmit via SLIP-OSC communication protocol.
+- The blobs coordinates, size and presure are transmit via SLIP-OSC communication protocol, and won't be visible with the Arduino serial monitor.
+
+### OSC Messages
+
+The host application is pulling the values from the Teensy :
+- `/b` : get blobs values
+- `/r` : get raw datas (16 * 16 Analog values)
+- `/i` : get interpolated datas (64 * 64 Analog values)
+
+The host application can also set parameters :
+- `/c value` : calibrate the sensor (vallue = how many iteration to avrage)
+- `/t value` : set the thresold value
 
 ## SLIP-OSC data paket
 ### on_touch_pressed

--- a/Software/Puredata_SLIP-OSC/README.md
+++ b/Software/Puredata_SLIP-OSC/README.md
@@ -1,0 +1,30 @@
+## eTextile Matrix Sensor - E256 / Pure Data
+> A simple patch made to work with the E256 eTextile Matrix Sensor connected via USB to any host.
+
+####  For an explanation of the E256 communication protocol see the [FIRMWARE_README](../Firmware/README.md "FIRMWARE_README").
+
+![preview](https://user-images.githubusercontent.com/9277107/80432942-ea484480-8938-11ea-800a-5bbaf9c863eb.png)
+
+### Requirements
+ - [Pure Data](http://puredata.info/downloads)
+    - Miller S. Puckette's "vanilla" distribution of Pd is perfect.
+ - [Externals](https://puredata.info/docs/faq/how-do-i-install-externals-and-help-files)
+    - `comport`, for Virtual COMs
+    - `mrpeach`, for SLIP encoding
+    - `OSC`, for OSC packing
+
+### Overview
+
+Our entry point is `Get_matrix_OSC.pd` with `e256_input_filters.pd` acting as a sub-patch.
+
+##### Input
+
+The patch establishes a connection over with the `comport` object. However, there are no assumptions made about which port the e256 is available on, so be sure to adjust `open 1` where "1" is your COM port.
+
+##### Configuration
+
+The embedded _e256_SLIP-OSC_input_ sub-patch handles communication with the e256 via SLIP encoded OSC. There are 3 UI objects to adjust for **calibration**, **on/off** and **threshold** adjustment.
+
+##### Output
+
+The output is an OSC stream, available whenever the threshold is met, and sent across the `udpsend` object. This can be received within the patch via the `udpreceive` object, and printed to the console, or sent elsewhere, outside of Pure Data.


### PR DESCRIPTION
Just a couple of additions to the documentation encapsulating some of the knowledge I've gathered working with the eTextile Matrix.

- An overview of the recently added Pure Data patch.
- Information about OSC addressing/messaging attached to the firmware documentation.

I hope this might be useful for others. I'm only just started to get my head around it, so apologies if I've made some errors.